### PR TITLE
Remove invalid flag from doctl command

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -29,8 +29,8 @@ jobs:
       with:
         token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
-    - name: Log in to DigitalOcean Container Registry with short-lived credentials
-      run: doctl registry login --expiry-seconds 600
+    - name: Log in to DigitalOcean Container Registry
+      run: doctl registry login
 
     - name: Push image to DigitalOcean Container Registry
       run: docker push registry.digitalocean.com/asb/static-example:$(echo $GITHUB_SHA | head -c7)


### PR DESCRIPTION
doctl no longer offers the --expiry-seconds flag for registry login and this will cause builds using this template to fail.

```
$ doctl registry login --expiry-seconds 600
Error: unknown flag: --expiry-seconds
Usage:
unknown flag: --expiry-seconds
  doctl registry login [flags]

Flags:
  -h, --help   help for login

Global Flags:
  -t, --access-token string   API V2 access token
  -u, --api-url string        Override default API endpoint
  -c, --config string         Specify a custom config file (default "/home/runner/.config/doctl/config.yaml")
      --context string        Specify a custom authentication context name
  -o, --output string         Desired output format [text|json] (default "text")
      --trace                 Show a log of network activity while performing a command
  -v, --verbose               Enable verbose output

Error: Process completed with exit code 255.
```